### PR TITLE
Include boost format to avoid build errors

### DIFF
--- a/lifecycle/src/lifecycle/client.cpp
+++ b/lifecycle/src/lifecycle/client.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <list>
 
+#include <boost/format.hpp>
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>

--- a/lifecycle/src/lifecycle/manager.cpp
+++ b/lifecycle/src/lifecycle/manager.cpp
@@ -19,6 +19,7 @@
 #include "lifecycle/manager.h"
 #include "lifecycle/lifecycle_model.h"
 #include "lifecycle/broadcaster.h"
+#include <boost/format.hpp>
 #include <ros/callback_queue_interface.h>
 
 namespace ros { namespace lifecycle {


### PR DESCRIPTION
I encountered the following errors when building on Ubuntu 18.04 + Melodic:

```
ros1_lifecycle/lifecycle/src/lifecycle/manager.cpp: In constructor ‘ros::lifecycle::IllegalTransitionException::IllegalTransitionException(const PrimaryInput&)’:
ros1_lifecycle/lifecycle/src/lifecycle/manager.cpp:265:26: error: ‘format’ is not a member of ‘boost’
     message = str(boost::format("IllegalTransitionException state=%1%, transition=%2%") %
                          ^~~~~~
ros1_lifecycle/lifecycle/src/lifecycle/manager.cpp:265:26: note: suggested alternative: ‘forward’
     message = str(boost::format("IllegalTransitionException state=%1%, transition=%2%") %
                          ^~~~~~
                          forward
ros1_lifecycle/lifecycle/src/lifecycle/manager.cpp:265:15: error: ‘str’ was not declared in this scope
     message = str(boost::format("IllegalTransitionException state=%1%, transition=%2%") %
```

Including boost/format.hpp fixes it.