### PR TITLE
Import lifecycle_model in python3

### DIFF
--- a/lifecycle_python/src/lifecycle/client.py
+++ b/lifecycle_python/src/lifecycle/client.py
@@ -23,7 +23,7 @@ from actionlib.action_client import CommState
 from actionlib_msgs.msg import GoalStatus
 
 from lifecycle_msgs.msg import LifecycleGoal, LifecycleAction, Lifecycle
-from lifecycle_model import LifecycleModel
+from lifecycle.lifecycle_model import LifecycleModel
 
 LIFECYCLE_ACTION_NAME = "lifecycle"
 LIFECYCLE_STATE_TOPIC = "lifecycle_state"

--- a/lifecycle_python/src/lifecycle/manager.py
+++ b/lifecycle_python/src/lifecycle/manager.py
@@ -6,7 +6,7 @@ import rospy
 import actionlib
 
 from lifecycle_msgs.msg import LifecycleGoal, LifecycleAction, LifecycleResult, Lifecycle
-from lifecycle_model import State, Transition, Result_Code, LifecycleModel
+from lifecycle.lifecycle_model import State, Transition, Result_Code, LifecycleModel
 from lifecycle.broadcaster import LmEventBroadcaster
 
 LIFECYCLE_ACTION_NAME = "lifecycle"

--- a/lm_monitor/src/lm_monitor/listener.py
+++ b/lm_monitor/src/lm_monitor/listener.py
@@ -8,7 +8,7 @@ import rospy
 import threading
 
 from lifecycle_msgs.msg import lm_events
-from monitor import LmMonitor
+from lm_monitor.monitor import LmMonitor
 
 class ListenerCbException(Exception):
     """


### PR DESCRIPTION
I was getting `ModuleNotFoundError: No module named 'lifecycle_model'` in python 3 in 20.04 and noetic before this change.
