### PR TITLE
Fixed lifecycle_state not latching in cpp manager

### DIFF
--- a/lifecycle/src/lifecycle/manager.cpp
+++ b/lifecycle/src/lifecycle/manager.cpp
@@ -59,7 +59,7 @@ LifecycleManager::LifecycleManager(const ros::NodeHandle& nh) :
     
     setTransitionCallback(ERROR, boost::bind(&LifecycleManager::activeEx_cb, this) );
 
-    state_pub_ = nh_.advertise<lifecycle_msgs::Lifecycle>(LIFECYCLE_STATE_TOPIC, true);
+    state_pub_ = nh_.advertise<lifecycle_msgs::Lifecycle>(LIFECYCLE_STATE_TOPIC, 1, true);
     as_.registerGoalCallback(boost::bind(&LifecycleManager::goalCb, this));
 }
 


### PR DESCRIPTION
The lifecycle_state message publisher uses the wrong function definition, presuming topic latching is intended. The bool for `latched` is in place of `queue_size` so it resolves to 1. Changed function call to match definition by including `queue_size` and `latched` arguments.