### PR TITLE
GitHub actions for kinetic, melodic, and noetic

### DIFF
--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -1,0 +1,73 @@
+name: Kinetic & Melodic ROS CI
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os_distro: [[ubuntu-16.04, kinetic], [ubuntu-18.04, melodic]]
+    runs-on: ${{ matrix.os_distro[0] }}
+    env:
+      ROS_CI_DESKTOP: "`lsb_release -cs`"  # e.g. [trusty|xenial|...]
+      ROS_DISTRO: ${{ matrix.os_distro[1] }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: catkin_ws/src/ros1_lifecycle
+      ### ROS ###
+      - name: Setup for ROS ${{ matrix.os_distro[1] }} install
+        run: |
+            sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+            sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+            sudo apt-get update -qq
+            sudo apt-get install dpkg
+      - name: Install ROS basic packages
+        run: |
+            sudo apt-get install -y python-catkin-pkg
+            sudo apt-get install -y python-catkin-tools
+            sudo apt-get install -y python-rosdep
+            sudo apt-get install -y python-rospkg
+            sudo apt-get install -y python-wstool
+            sudo apt-get install -y ros-$ROS_DISTRO-ros-base
+            source /opt/ros/$ROS_DISTRO/setup.bash
+            # Prepare rosdep to install dependencies.
+            sudo rosdep init
+            rosdep update
+      - name: Install ROS additional packages with rosdep
+        run: |
+            source /opt/ros/$ROS_DISTRO/setup.bash
+            cd catkin_ws
+            rosdep install --from-paths src --ignore-src -r -s  # do a dry-run first
+            rosdep install --from-paths src --ignore-src -r -y
+      - name: Catkin build install
+        run: |
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          mkdir -p catkin_ws/src
+          cd catkin_ws
+          catkin config --install --cmake-args -DCMAKE_BUILD_TYPE=Release
+          catkin build --no-status
+          source install/setup.bash
+      - name: test installed import
+        run: |
+          cd catkin_ws
+          source install/setup.bash
+          python --version
+          # very basic test which may reveal a change made for python3 breaks here in python2
+          python -c "import lifecycle.managed_node"
+          python -c "from lifecycle.lifecycle_model import State, Transition, Result_Code, LifecycleModel"
+      - name: Catkin build devel
+        run: |
+          cd catkin_ws
+          rm -rf .catkin_tools build install logs
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          catkin build --no-status
+          source devel/setup.bash
+      - name: test devel imports and example roslaunch
+        run: |
+          cd catkin_ws
+          source devel/setup.bash
+          # very basic test which may reveal a change made for python3 breaks here in python2
+          python -c "import lifecycle.managed_node"
+          python -c "from lifecycle.lifecycle_model import State, Transition, Result_Code, LifecycleModel"
+          roslaunch `rospack find lifecycle_test_library`/examples/launch/lifecycle_test.launch

--- a/.github/workflows/ubuntu_18_04.yml
+++ b/.github/workflows/ubuntu_18_04.yml
@@ -18,28 +18,28 @@ jobs:
       ### ROS ###
       - name: Setup for ROS ${{ matrix.os_distro[1] }} install
         run: |
-            sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-            sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-            sudo apt-get update -qq
-            sudo apt-get install dpkg
+          sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+          sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+          sudo apt-get update -qq
+          sudo apt-get install dpkg
       - name: Install ROS basic packages
         run: |
-            sudo apt-get install -y python-catkin-pkg
-            sudo apt-get install -y python-catkin-tools
-            sudo apt-get install -y python-rosdep
-            sudo apt-get install -y python-rospkg
-            sudo apt-get install -y python-wstool
-            sudo apt-get install -y ros-$ROS_DISTRO-ros-base
-            source /opt/ros/$ROS_DISTRO/setup.bash
-            # Prepare rosdep to install dependencies.
-            sudo rosdep init
-            rosdep update
+          sudo apt-get install -y python-catkin-pkg
+          sudo apt-get install -y python-catkin-tools
+          sudo apt-get install -y python-rosdep
+          sudo apt-get install -y python-rospkg
+          sudo apt-get install -y python-wstool
+          sudo apt-get install -y ros-$ROS_DISTRO-ros-base
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          # Prepare rosdep to install dependencies.
+          sudo rosdep init
+          rosdep update
       - name: Install ROS additional packages with rosdep
         run: |
-            source /opt/ros/$ROS_DISTRO/setup.bash
-            cd catkin_ws
-            rosdep install --from-paths src --ignore-src -r -s  # do a dry-run first
-            rosdep install --from-paths src --ignore-src -r -y
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          cd catkin_ws
+          rosdep install --from-paths src --ignore-src -r -s  # do a dry-run first
+          rosdep install --from-paths src --ignore-src -r -y
       - name: Catkin build install
         run: |
           source /opt/ros/$ROS_DISTRO/setup.bash
@@ -47,7 +47,6 @@ jobs:
           cd catkin_ws
           catkin config --install --cmake-args -DCMAKE_BUILD_TYPE=Release
           catkin build --no-status
-          source install/setup.bash
       - name: test installed import
         run: |
           cd catkin_ws
@@ -61,7 +60,7 @@ jobs:
           cd catkin_ws
           rm -rf .catkin_tools build install logs
           source /opt/ros/$ROS_DISTRO/setup.bash
-          catkin build --no-status
+          catkin build --no-status -DCMAKE_BUILD_TYPE=Debug
           source devel/setup.bash
       - name: test devel imports and example roslaunch
         run: |

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -1,0 +1,77 @@
+name: Noetic ROS CI
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os_distro: [[ubuntu-20.04, noetic]]
+    runs-on: ${{ matrix.os_distro[0] }}
+    env:
+      ROS_CI_DESKTOP: "`lsb_release -cs`"  # e.g. [trusty|xenial|...]
+      ROS_DISTRO: ${{ matrix.os_distro[1] }}
+      ACCEPT_EULA: true
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: catkin_ws/src/ros1_lifecycle
+      ### ROS ###
+      - name: Setup for ROS ${{ matrix.os_distro[1] }} install
+        run: |
+            sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+            # this breaks catkin
+            # sudo sh -c "echo \"deb http://packages.ros.org/ros-testing/ubuntu `lsb_release -cs` main\" > /etc/apt/sources.list.d/ros1-testing.list"
+            sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+            sudo apt-get update -y
+            sudo apt-get upgrade -y
+            sudo apt-get install -y dpkg
+      - name: Install ROS basic packages
+        run: |
+            sudo apt-get install -y python3-catkin-pkg
+            sudo apt-get install -y python3-catkin-tools
+            sudo apt-get install -y python3-rosdep
+            sudo apt-get install -y python3-wstool
+            sudo apt-get install -y python3-osrf-pycommon
+            sudo apt-get install -y ros-cmake-modules
+            sudo apt-get install -y ros-$ROS_DISTRO-ros-base
+            source /opt/ros/$ROS_DISTRO/setup.bash
+            sudo rosdep init
+            rosdep update
+      - name: Install ROS additional packages with rosdep
+        run: |
+            source /opt/ros/$ROS_DISTRO/setup.bash
+            cd catkin_ws
+            rosdep install --from-paths src --ignore-src -r -s  # do a dry-run first
+            rosdep install --from-paths src --ignore-src -r -y
+      - name: build
+        run: |
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          cd catkin_ws
+          catkin config --install --cmake-args -DCMAKE_BUILD_TYPE=Release
+          catkin build --no-status
+          source install/setup.bash
+      - name: test import
+        run: |
+          cd catkin_ws
+          source install/setup.bash
+          which python
+          python3 --version
+          # very basic test which may reveal a change made for python2 breaks here in python3
+          python3 -c "import lifecycle.managed_node"
+          python3 -c "from lifecycle.lifecycle_model import State, Transition, Result_Code, LifecycleModel"
+      - name: test devel build
+        run: |
+          cd catkin_ws
+          rm -rf .catkin_tools build install logs
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          catkin build --no-status
+          source devel/setup.bash
+      - name: test devel imports and roslaunch
+        run: |
+          cd catkin_ws
+          source devel/setup.bash
+          # very basic test which may reveal a change made for python2 breaks here in python3
+          python3 -c "import lifecycle.managed_node"
+          python3 -c "from lifecycle.lifecycle_model import State, Transition, Result_Code, LifecycleModel"
+          roslaunch `rospack find lifecycle_test_library`/examples/launch/lifecycle_test.launch

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -19,38 +19,35 @@ jobs:
       ### ROS ###
       - name: Setup for ROS ${{ matrix.os_distro[1] }} install
         run: |
-            sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-            # this breaks catkin
-            # sudo sh -c "echo \"deb http://packages.ros.org/ros-testing/ubuntu `lsb_release -cs` main\" > /etc/apt/sources.list.d/ros1-testing.list"
-            sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-            sudo apt-get update -y
-            sudo apt-get upgrade -y
-            sudo apt-get install -y dpkg
+          sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+          sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+          sudo apt-get update -y
+          sudo apt-get upgrade -y
+          sudo apt-get install -y dpkg
       - name: Install ROS basic packages
         run: |
-            sudo apt-get install -y python3-catkin-pkg
-            sudo apt-get install -y python3-catkin-tools
-            sudo apt-get install -y python3-rosdep
-            sudo apt-get install -y python3-wstool
-            sudo apt-get install -y python3-osrf-pycommon
-            sudo apt-get install -y ros-cmake-modules
-            sudo apt-get install -y ros-$ROS_DISTRO-ros-base
-            source /opt/ros/$ROS_DISTRO/setup.bash
-            sudo rosdep init
-            rosdep update
+          sudo apt-get install -y python3-catkin-pkg
+          sudo apt-get install -y python3-catkin-tools
+          sudo apt-get install -y python3-rosdep
+          sudo apt-get install -y python3-wstool
+          sudo apt-get install -y python3-osrf-pycommon
+          sudo apt-get install -y ros-cmake-modules
+          sudo apt-get install -y ros-$ROS_DISTRO-ros-base
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          sudo rosdep init
+          rosdep update
       - name: Install ROS additional packages with rosdep
         run: |
-            source /opt/ros/$ROS_DISTRO/setup.bash
-            cd catkin_ws
-            rosdep install --from-paths src --ignore-src -r -s  # do a dry-run first
-            rosdep install --from-paths src --ignore-src -r -y
-      - name: build
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          cd catkin_ws
+          rosdep install --from-paths src --ignore-src -r -s  # do a dry-run first
+          rosdep install --from-paths src --ignore-src -r -y
+      - name: install build
         run: |
           source /opt/ros/$ROS_DISTRO/setup.bash
           cd catkin_ws
           catkin config --install --cmake-args -DCMAKE_BUILD_TYPE=Release
           catkin build --no-status
-          source install/setup.bash
       - name: test import
         run: |
           cd catkin_ws
@@ -65,7 +62,7 @@ jobs:
           cd catkin_ws
           rm -rf .catkin_tools build install logs
           source /opt/ros/$ROS_DISTRO/setup.bash
-          catkin build --no-status
+          catkin build --no-status -DCMAKE_BUILD_TYPE=Debug
           source devel/setup.bash
       - name: test devel imports and roslaunch
         run: |

--- a/lifecycle_python/src/lifecycle/client.py
+++ b/lifecycle_python/src/lifecycle/client.py
@@ -23,7 +23,7 @@ from actionlib.action_client import CommState
 from actionlib_msgs.msg import GoalStatus
 
 from lifecycle_msgs.msg import LifecycleGoal, LifecycleAction, Lifecycle
-from lifecycle_model import LifecycleModel
+from lifecycle.lifecycle_model import LifecycleModel
 
 LIFECYCLE_ACTION_NAME = "lifecycle"
 LIFECYCLE_STATE_TOPIC = "lifecycle_state"

--- a/lifecycle_python/src/lifecycle/manager.py
+++ b/lifecycle_python/src/lifecycle/manager.py
@@ -6,7 +6,7 @@ import rospy
 import actionlib
 
 from lifecycle_msgs.msg import LifecycleGoal, LifecycleAction, LifecycleResult, Lifecycle
-from lifecycle_model import State, Transition, Result_Code, LifecycleModel
+from lifecycle.lifecycle_model import State, Transition, Result_Code, LifecycleModel
 from lifecycle.broadcaster import LmEventBroadcaster
 
 LIFECYCLE_ACTION_NAME = "lifecycle"

--- a/lifecycle_test_library/examples/launch/lifecycle_test.launch
+++ b/lifecycle_test_library/examples/launch/lifecycle_test.launch
@@ -4,4 +4,5 @@
         <rosparam command="load" file="$(find lifecycle_test_library)/examples/config/example_test.yaml"/>
     </node>
 
+    <node pkg="lifecycle_test_library" type="managed_node_example.py" name="Example_Node" output="screen" />
 </launch>

--- a/lm_monitor/src/lm_monitor/listener.py
+++ b/lm_monitor/src/lm_monitor/listener.py
@@ -8,7 +8,7 @@ import rospy
 import threading
 
 from lifecycle_msgs.msg import lm_events
-from monitor import LmMonitor
+from lm_monitor.monitor import LmMonitor
 
 class ListenerCbException(Exception):
     """


### PR DESCRIPTION
Resolves #8 

Could add in 16.04 support if desired.

Had to base this on the 20.04 python3 fixes from #4 to make the noetic build work- could disable the 20.04 action here now then re-introduce after that PR is merged.

Two lifecycle imports are getting run, other than building that is the only test.

This test is getting called manually and working:
```
roslaunch `rospack find lifecycle_test_library`/examples/launch/lifecycle_test.launch
```

Making it into a regular rostest ought to be in another PR so when it fails CI fails also.

Probably could make use of more actions and actions features but I like the straight forward style and mostly being able to cut and paste straight out of the yaml into a terminal to duplicate.  Could revisit that in the future.